### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.1",
         "codeception/codeception": "^2.2",
         "alecsammon/php-raml-parser": "^2.1",
-        "laravel/framework": "^5.3",
+        "laravel/framework": "5.3.* || 5.4.* || 5.5.*",
         "nwidart/laravel-modules": "^1.14",
         "league/fractal": ">=0.14",
         "lcobucci/jwt": "^3.2"


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.