### PR TITLE
Fix UUID implementation in models errors the API

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at arthurkushman@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/src/extension/ApiController.php
+++ b/src/extension/ApiController.php
@@ -121,7 +121,7 @@ class ApiController extends Controller
      * @param int $id
      * @throws \rjapi\exception\AttributesException
      */
-    public function view(Request $request, int $id)
+    public function view(Request $request, $id)
     {
         $meta = [];
         $data = ($request->input(ModelsInterface::PARAM_DATA) === null) ? ModelsInterface::DEFAULT_DATA

--- a/src/extension/BaseModelTrait.php
+++ b/src/extension/BaseModelTrait.php
@@ -24,7 +24,7 @@ trait BaseModelTrait
      *
      * @return mixed
      */
-    private function getEntity(int $id, array $data = ModelsInterface::DEFAULT_DATA)
+    private function getEntity($id, array $data = ModelsInterface::DEFAULT_DATA)
     {
         $obj = call_user_func_array(
             PhpInterface::BACKSLASH . $this->modelEntity . PhpInterface::DOUBLE_COLON
@@ -49,7 +49,7 @@ trait BaseModelTrait
      *
      * @return mixed
      */
-    private function getModelEntity($modelEntity, int $id)
+    private function getModelEntity($modelEntity, $id)
     {
         $obj = call_user_func_array(
             PhpInterface::BACKSLASH . $modelEntity . PhpInterface::DOUBLE_COLON
@@ -140,7 +140,7 @@ trait BaseModelTrait
      * @param int $id
      * @return array
      */
-    private function buildTree(Collection $data, int $id = 0)
+    private function buildTree(Collection $data, $id = 0)
     {
         $tree = [];
         foreach ($data as $k => $child) {
@@ -161,7 +161,7 @@ trait BaseModelTrait
      * @param int $id
      * @return array
      */
-    public function getSubTreeEntities(SqlOptions $sqlOptions, int $id) : array
+    public function getSubTreeEntities(SqlOptions $sqlOptions, $id) : array
     {
         return $this->buildSubTree($this->getAllEntities($sqlOptions), $id);
     }
@@ -174,7 +174,7 @@ trait BaseModelTrait
      * @param bool $isParentFound
      * @return array
      */
-    private function buildSubTree(Collection $data, int $searchId, int $id = 0, bool $isParentFound = false)
+    private function buildSubTree(Collection $data, $searchId, $id = 0, bool $isParentFound = false)
     {
         $tree = [];
         foreach ($data as $k => $child) {

--- a/src/helpers/Jwt.php
+++ b/src/helpers/Jwt.php
@@ -19,7 +19,7 @@ class Jwt
      *
      * @return string
      */
-    public static function create(int $uid, string $generatedId) : string
+    public static function create($uid, string $generatedId): string
     {
         $signer = new Sha256();
 


### PR DESCRIPTION
When using the UUID as primary key in the models, the restriction on id to be an integer is lifted thereby allowing for any kind of primary key.